### PR TITLE
preserve multiple forwards

### DIFF
--- a/lib/dotforward.class.php
+++ b/lib/dotforward.class.php
@@ -115,7 +115,11 @@ class DotForward {
                 $this->options['enabled'] = !empty($this->options['binary']);
             } else {
 
-                $this->options['forward'] = $next;
+                if ( $this->options['forward'] ) {
+                    $this->options['forward'] = $this->options['forward'] . ', ' . $next;
+                } else {
+                    $this->options['forward'] = $next;
+                }
             }
         }
 


### PR DESCRIPTION
This allows more than one forward address separated by comma instead
of using just last one and loosing others