### PR TITLE
parse files with multiple lines and comments

### DIFF
--- a/lib/dotforward.class.php
+++ b/lib/dotforward.class.php
@@ -80,6 +80,10 @@ class DotForward {
     
     public function parse($dotForward) {
 
+        // parse files with multiple lines and comments like squirrelmail .forward
+        $dotForward = preg_replace('/#[^\n\r]+/','', $dotForward); // remove comments
+        $dotForward = preg_replace('/[\n\r]/',',', $dotForward);   // join lines with comma
+
         // Clean up the .forward file for easier parsing
         $dotForward = str_replace(array("|", "\"", "\\"), "", $dotForward);
 


### PR DESCRIPTION
squirrelmail .forward files are created as multiple lines with
comment which might include forward address if disabled. There is
no way to preserve disabled forward address, but this allows
migration from squirrelmail (or other existing forward files) to
roundcube with this plugin.