### PR TITLE
fixing postgresql syntax

### DIFF
--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -48,7 +48,7 @@ class Virtual extends VacationDriver {
         //   print_r($vacArr);
         $fwdArr = $this->virtual_alias();
 
-        $sql = sprintf("SELECT subject,body,active FROM {$this->cfg['dbase']}.vacation WHERE email='%s'",
+        $sql = sprintf("SELECT subject,body,active FROM vacation WHERE email='%s'",
                 rcube::Q($this->user->data['username']));
 
         $res = $this->db->query($sql);
@@ -83,7 +83,7 @@ class Virtual extends VacationDriver {
         // Sets class property
         $this->domain_id = $this->domainLookup();
 
-        $sql = sprintf("UPDATE {$this->cfg['dbase']}.vacation SET created=now(),active=FALSE WHERE email='%s'", rcube::Q($this->user->data['username']));
+        $sql = sprintf("UPDATE vacation SET created=now(),active=FALSE WHERE email='%s'", rcube::Q($this->user->data['username']));
 
 
         $this->db->query($sql);
@@ -110,11 +110,11 @@ class Virtual extends VacationDriver {
 
 	      // LIMIT date arbitrarily put to next century (vacation.pl doesn't like NULL value)
         if (!$update) {
-            $sql = "INSERT INTO {$this->cfg['dbase']}.vacation ".
+            $sql = "INSERT INTO vacation ".
                 "( email, subject, body, cache, domain, created, active, activefrom, activeuntil ) ".
-                "VALUES ( ?, ?, ?, '', ?, NOW(), ?, NOW(), NOW() + INTERVAL + 10 YEAR )";
+                "VALUES ( ?, ?, ?, '', ?, NOW(), ?, NOW(), NOW() + INTERVAL '100 YEAR' )";
         } else {
-            $sql = "UPDATE {$this->cfg['dbase']}.vacation SET email=?,subject=?,body=?,domain=?,active=?, activefrom=NOW(), activeuntil=NOW() + INTERVAL + 10 YEAR WHERE email=?";
+            $sql = "UPDATE vacation SET email=?,subject=?,body=?,domain=?,active=?, activefrom=NOW(), activeuntil=NOW() + INTERVAL '100 YEAR' WHERE email=?";
         }
 	      if ($this->enable == '') {
             $this->enable = 0;


### PR DESCRIPTION
Hi, just pushing some changes to fix postgresql compatibility here.
This changes are currently working for me, in production with Pg v12.3.

1) the 'database.table' syntax is mysql specific, in postgresql you can at best mention a schema in query

2) the 'INTERVAL' keyword just doesn't work that way, I simply don't understand how this code could have ever worked.

3) the comments are talking of adding a century but the code was only adding 10 years.