### PR TITLE
Add port option for FTP and SSH

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,9 @@ This driver has no configuration options. Use this driver to disable the
 - server = "ftp.host.org"
 If 'server' is omitted, the FTP driver will use the current IMAP-server as server. Optional.
 
+- port = "21"
+If 'port' is omitted, the FTP driver will use the default port 21. Optional.
+
 - passive = False
 If set, the FTP driver will try to establish a passive FTP connection. Optional.
 
@@ -41,6 +44,9 @@ If set to True, the end-user will not be able to set forwards. Defaults to false
 [*** SSHFTP Driver ***]
 - server = "ssh.host.org"
 If 'server' is omitted, the SSHFTP driver will use the current IMAP-server as server. Optional.
+
+- port = "22"
+If 'port' is omitted, the SSHFTP driver will use the default port 22. Optional.
 
 - disable_forward = False
 If set to True, the end-user will not be able to set forwards. Defaults to false. Optional.

--- a/lib/ftp.class.php
+++ b/lib/ftp.class.php
@@ -18,9 +18,15 @@ class FTP extends VacationDriver {
 		$username_fields = explode('@',rcube::Q($this->user->data['username']),2);
         	$this->user->data['username'] = $username = $username_fields[0];
 		$userpass = $this->rcmail->decrypt($_SESSION['password']);
-
+		
+		if (array_key_exists('port',$this->cfg)){
+			$port = $this->cfg['port'] ;
+		} else {
+			$port = 21 ;
+		}
+		
 		// 15 second time-out
-		if (! $this->ftp = ftp_ssl_connect($this->cfg['server'],21,15)) {
+		if (! $this->ftp = ftp_ssl_connect($this->cfg['server'],$port,15)) {
 			 rcube::raise_error(array('code' => 601, 'type' => 'php', 'file' => __FILE__,
                 'message' => sprintf("Vacation plugin: Cannot connect to the FTP-server '%s'",$this->cfg['server'])
 			),true, true);

--- a/lib/sshftp.class.php
+++ b/lib/sshftp.class.php
@@ -25,8 +25,14 @@ class SSHFTP extends VacationDriver {
 		$userpass = $this->rcmail->decrypt($_SESSION['password']);
 
 		$callback = array();
-				
-		if (! $this->conn = ssh2_connect($this->cfg['server'],22,null,$callback)) {
+		
+		if (array_key_exists('port',$this->cfg)){
+			$port = $this->cfg['port'] ;
+		} else {
+			$port = 22 ;
+		}
+		
+		if (! $this->conn = ssh2_connect($this->cfg['server'],$port,null,$callback)) {
 			 rcube::raise_error(array('code' => 601, 'type' => 'php', 'file' => __FILE__,
                 'message' => sprintf("Vacation plugin: Cannot connect to the SSH-server '%s'",$this->cfg['server'])
 			),true, true);


### PR DESCRIPTION
Enable the possibility to use a custom FTP and SSH port. The port, optional, is set in the config.ini