### PR TITLE
Small upgrade for PHP 8 compatibility

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,9 @@ This driver has no configuration options. Use this driver to disable the
 - server = "ftp.host.org"
 If 'server' is omitted, the FTP driver will use the current IMAP-server as server. Optional.
 
+- port = "21"
+If 'port' is omitted, the FTP driver will use the default port 21. Optional.
+
 - passive = False
 If set, the FTP driver will try to establish a passive FTP connection. Optional.
 
@@ -41,6 +44,9 @@ If set to True, the end-user will not be able to set forwards. Defaults to false
 [*** SSHFTP Driver ***]
 - server = "ssh.host.org"
 If 'server' is omitted, the SSHFTP driver will use the current IMAP-server as server. Optional.
+
+- port = "22"
+If 'port' is omitted, the SSHFTP driver will use the default port 22. Optional.
 
 - disable_forward = False
 If set to True, the end-user will not be able to set forwards. Defaults to false. Optional.

--- a/lib/ftp.class.php
+++ b/lib/ftp.class.php
@@ -18,9 +18,15 @@ class FTP extends VacationDriver {
 		$username_fields = explode('@',rcube::Q($this->user->data['username']),2);
         	$this->user->data['username'] = $username = $username_fields[0];
 		$userpass = $this->rcmail->decrypt($_SESSION['password']);
-
+		
+		if (array_key_exists('port',$this->cfg)){
+			$port = $this->cfg['port'] ;
+		} else {
+			$port = 21 ;
+		}
+		
 		// 15 second time-out
-		if (! $this->ftp = ftp_ssl_connect($this->cfg['server'],21,15)) {
+		if (! $this->ftp = ftp_ssl_connect($this->cfg['server'],$port,15)) {
 			 rcube::raise_error(array('code' => 601, 'type' => 'php', 'file' => __FILE__,
                 'message' => sprintf("Vacation plugin: Cannot connect to the FTP-server '%s'",$this->cfg['server'])
 			),true, true);

--- a/lib/sshftp.class.php
+++ b/lib/sshftp.class.php
@@ -25,8 +25,14 @@ class SSHFTP extends VacationDriver {
 		$userpass = $this->rcmail->decrypt($_SESSION['password']);
 
 		$callback = array();
-				
-		if (! $this->conn = ssh2_connect($this->cfg['server'],22,null,$callback)) {
+		
+		if (array_key_exists('port',$this->cfg)){
+			$port = $this->cfg['port'] ;
+		} else {
+			$port = 22 ;
+		}
+		
+		if (! $this->conn = ssh2_connect($this->cfg['server'],$port,null,$callback)) {
 			 rcube::raise_error(array('code' => 601, 'type' => 'php', 'file' => __FILE__,
                 'message' => sprintf("Vacation plugin: Cannot connect to the SSH-server '%s'",$this->cfg['server'])
 			),true, true);

--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -26,13 +26,13 @@ class Virtual extends VacationDriver {
 
         if (empty($this->cfg['dsn'])) {
             $this->db = $this->rcmail->db;
-            $dsn = MDB2::parseDSN($this->rcmail->config->get('db_dsnw'));
+            $dsn = self::parseDSN($this->rcmail->config->get('db_dsnw'));
         } else {
             $this->db = new rcube_db($this->cfg['dsn'], '', FALSE);
             $this->db->db_connect('w');
 
             $this->db->set_debug((bool) $this->rcmail->config->get('sql_debug'));
-            $dsn = MDB2::parseDSN($this->cfg['dsn']);
+            $dsn = self::parseDSN($this->cfg['dsn']);
             $this->db->set_debug(true);
 
         }
@@ -297,6 +297,173 @@ class Virtual extends VacationDriver {
         if (!empty($this->cfg['dsn']) && is_resource($this->db)) {
             $this->db = null;
         }
+    }
+
+    /**
+     * Parse a data source name.
+     *
+     * Additional keys can be added by appending a URI query string to the
+     * end of the DSN.
+     *
+     * The format of the supplied DSN is in its fullest form:
+     * <code>
+     *  phptype(dbsyntax)://username:password@protocol+hostspec/database?option=8&another=true
+     * </code>
+     *
+     * Most variations are allowed:
+     * <code>
+     *  phptype://username:password@protocol+hostspec:110//usr/db_file.db?mode=0644
+     *  phptype://username:password@hostspec/database_name
+     *  phptype://username:password@hostspec
+     *  phptype://username@hostspec
+     *  phptype://hostspec/database
+     *  phptype://hostspec
+     *  phptype(dbsyntax)
+     *  phptype
+     * </code>
+     *
+     * @param   string  Data Source Name to be parsed
+     *
+     * @return  array   an associative array with the following keys:
+     *  + phptype:  Database backend used in PHP (mysql, odbc etc.)
+     *  + dbsyntax: Database used with regards to SQL syntax etc.
+     *  + protocol: Communication protocol to use (tcp, unix etc.)
+     *  + hostspec: Host specification (hostname[:port])
+     *  + database: Database to use on the DBMS server
+     *  + username: User name for login
+     *  + password: Password for login
+     *
+     * @access  public
+     * @author  Tomas V.V.Cox <cox@idecnet.com>
+     * @note    This function was extracted & adapted from Pear->MDB2 (see https://pear.php.net/package/mdb2)
+     */
+    private function parseDSN($dsn)
+    {
+        $parsed = [
+          'phptype'  => false,
+          'dbsyntax' => false,
+          'username' => false,
+          'password' => false,
+          'protocol' => false,
+          'hostspec' => false,
+          'port'     => false,
+          'socket'   => false,
+          'database' => false,
+          'mode'     => false,
+        ];
+
+        if (is_array($dsn)) {
+            $dsn = array_merge($parsed, $dsn);
+            if (!$dsn['dbsyntax']) {
+                $dsn['dbsyntax'] = $dsn['phptype'];
+            }
+            return $dsn;
+        }
+
+        // Find phptype and dbsyntax
+        if (($pos = strpos($dsn, '://')) !== false) {
+            $str = substr($dsn, 0, $pos);
+            $dsn = substr($dsn, $pos + 3);
+        } else {
+            $str = $dsn;
+            $dsn = null;
+        }
+
+        // Get phptype and dbsyntax
+        // $str => phptype(dbsyntax)
+        if (preg_match('|^(.+?)\((.*?)\)$|', $str, $arr)) {
+            $parsed['phptype']  = $arr[1];
+            $parsed['dbsyntax'] = !$arr[2] ? $arr[1] : $arr[2];
+        } else {
+            $parsed['phptype']  = $str;
+            $parsed['dbsyntax'] = $str;
+        }
+
+        if (empty($dsn)) {
+            return $parsed;
+        }
+
+        // Get (if found): username and password
+        // $dsn => username:password@protocol+hostspec/database
+        if (($at = strrpos($dsn,'@')) !== false) {
+            $str = substr($dsn, 0, $at);
+            $dsn = substr($dsn, $at + 1);
+            if (($pos = strpos($str, ':')) !== false) {
+                $parsed['username'] = rawurldecode(substr($str, 0, $pos));
+                $parsed['password'] = rawurldecode(substr($str, $pos + 1));
+            } else {
+                $parsed['username'] = rawurldecode($str);
+            }
+        }
+
+        // Find protocol and hostspec
+
+        // $dsn => proto(proto_opts)/database
+        if (preg_match('|^([^(]+)\((.*?)\)/?(.*?)$|', $dsn, $match)) {
+            $proto       = $match[1];
+            $proto_opts  = $match[2] ? $match[2] : false;
+            $dsn         = $match[3];
+
+            // $dsn => protocol+hostspec/database (old format)
+        } else {
+            if (strpos($dsn, '+') !== false) {
+                list($proto, $dsn) = explode('+', $dsn, 2);
+            }
+            if (   strpos($dsn, '//') === 0
+              && strpos($dsn, '/', 2) !== false
+              && $parsed['phptype'] == 'oci8'
+            ) {
+                //oracle's "Easy Connect" syntax:
+                //"username/password@[//]host[:port][/service_name]"
+                //e.g. "scott/tiger@//mymachine:1521/oracle"
+                $proto_opts = $dsn;
+                $dsn = null;
+            } elseif (strpos($dsn, '/') !== false) {
+                list($proto_opts, $dsn) = explode('/', $dsn, 2);
+            } else {
+                $proto_opts = $dsn;
+                $dsn = null;
+            }
+        }
+
+        // process the different protocol options
+        $parsed['protocol'] = (!empty($proto)) ? $proto : 'tcp';
+        $proto_opts = rawurldecode($proto_opts);
+        if (strpos($proto_opts, ':') !== false) {
+            list($proto_opts, $parsed['port']) = explode(':', $proto_opts);
+        }
+        if ($parsed['protocol'] == 'tcp') {
+            $parsed['hostspec'] = $proto_opts;
+        } elseif ($parsed['protocol'] == 'unix') {
+            $parsed['socket'] = $proto_opts;
+        }
+
+        // Get dabase if any
+        // $dsn => database
+        if ($dsn) {
+            // /database
+            if (($pos = strpos($dsn, '?')) === false) {
+                $parsed['database'] = $dsn;
+                // /database?param1=value1&param2=value2
+            } else {
+                $parsed['database'] = substr($dsn, 0, $pos);
+                $dsn = substr($dsn, $pos + 1);
+                if (strpos($dsn, '&') !== false) {
+                    $opts = explode('&', $dsn);
+                } else { // database?param1=value1
+                    $opts = array($dsn);
+                }
+                foreach ($opts as $opt) {
+                    list($key, $value) = explode('=', $opt);
+                    if (!isset($parsed[$key])) {
+                        // don't allow params overwrite
+                        $parsed[$key] = rawurldecode($value);
+                    }
+                }
+            }
+        }
+
+        return $parsed;
     }
 }
 


### PR DESCRIPTION
After upgrading my server to PHP 8.1, this plugin stopped working.

In my changes, I haven't corrected everything, as I still see a bunch of warnings & deprecated lines in Roundcube's logs.
The only thing I did was to get rid of Pear->MDB2 dependency.

This MDB2 class was very old (from 2007) and this was bugging PHP 8.
After reading carefully the code, I realized only one function (parseDNS) was called from that class.

So I've imported that parseDNS function directly into lib/virtual.class.php.
I also slightly modified it for compatibility purpose (it was calling count() on a string).

This is working in prod for me, so I share and hope it will work for you too.

(Btw sorry for the mess with github, I did commit my changes before merging with this repo so I had to merge all the commit in between again. The ONLY change this pull request is bringing is the import of the parseDNS function from MDB2 to Virtual.)