### PR TITLE
compat fix for php82 and bugfix for mysql virtual driver

### DIFF
--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -128,12 +128,22 @@ class Virtual extends VacationDriver {
 	      if ($this->enable == '') {
             $this->enable = 0;
         }
+
+        //mysql version of postfixadmin vacation table use 'active' column with tinyint(1)
+        //pgsql version of postfixadmin vacation table use 'active' column with true/false bool
+        $enable_status = $this->enable;
+        if($this->db_is_postgres) {
+          $enable_status = $this->enable ? 'TRUE' : 'FALSE';
+        }else{
+          $enable_status = $this->enable ? '1' : '0';
+        }
+
         $this->db->query($sql, 
 	          rcube::Q($this->user->data['username']), 
 	          $this->subject, 
 	          $this->body,
 	          $this->domain,
-	          $this->enable ? 'TRUE' : 'FALSE',
+	          $enable_status,
 	          rcube::Q($this->user->data['username']));
         if ($error = $this->db->is_error()) {
             if (strpos($error, "no such field")) {

--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -13,6 +13,8 @@
 
 class Virtual extends VacationDriver {
 
+    public $identity;
+
     private $db, $domain, $domain_id, $goto = "";
     private $db_user;
     /** @var bool $db_is_postgres sometimes query's syntax depend on database

--- a/vacation.php
+++ b/vacation.php
@@ -21,6 +21,9 @@ require 'lib/VacationConfig.class.php';
 class vacation extends rcube_plugin {
 
     public $task = 'settings';
+    public $rcmail;
+    public $user;
+    public $identity;
     private $v = "";
     private $inicfg = "";
     private $enableVacationTab = true;
@@ -115,6 +118,9 @@ class vacation extends rcube_plugin {
         // Initialize the driver
         $this->v->init();
         $settings = $this->v->_get();
+
+        $out = '';
+        $class = ''; //$class not used
         
         // Load default body & subject if present.
         if (empty($settings['subject']) && $defaults = $this->v->loadDefaults()) {


### PR DESCRIPTION
**1. mysql virtual driver**
mysql version of postfixadmin vacation table use 'active' column with tinyint(1) while
postgres version of postfixadmin vacation table use 'active' column with true/false bool

this fix should allow both to work proper with the Setting UI

**2. php82 compatibility fixes**
this addresses the following PHP warnings and deprecated notices : 
```
- PHP Deprecated:  Creation of dynamic property Virtual::$identity is deprecated in /roundcube/plugins/vacation/lib/vacationdriver.class.php on line 27
- PHP Deprecated:  Creation of dynamic property vacation::$rcmail is deprecated in /roundcube/plugins/vacation/vacation.php on line 53
- PHP Deprecated:  Creation of dynamic property vacation::$user is deprecated in /roundcube/plugins/vacation/vacation.php on line 54
- PHP Deprecated:  Creation of dynamic property vacation::$identity is deprecated in /roundcube/plugins/vacation/vacation.php on line 55
- PHP Warning:  Undefined variable $class in /roundcube/plugins/vacation/vacation.php on line 152
- PHP Warning:  Undefined variable $out in /roundcube/plugins/vacation/vacation.php on line 152
```