### PR TITLE
virtual driver activeuntil interval defaults bugfix

### DIFF
--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -118,8 +118,8 @@ class Virtual extends VacationDriver {
 
         // Save vacation message in any case
 
-	      // LIMIT date arbitrarily put to next century (vacation.pl doesn't like NULL value)
-        $interval = $this->db_is_postgres ? "INTERVAL '100 YEAR'" : 'INTERVAL 100 YEAR';
+	// LIMIT date arbitrarily put to next century (vacation.pl doesn't like NULL value)
+        $interval = $this->db_is_postgres ? "INTERVAL '100 YEAR'" : 'INTERVAL 5 YEAR';
         if (!$update) {
             $sql = "INSERT INTO {$this->cfg['dbase']}.vacation ".
                 "( email, subject, body, cache, domain, created, active, activefrom, activeuntil ) ".


### PR DESCRIPTION
vacation interval defaults to NOW() + 100 year 
which will fail for most mysql setup as the postfixadmin default schema use mysql type=timestamp.

resulting in mysql warning : Out of range value for column 'activeuntil' at row 1 


`TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.`

setting to NOW() + 5 year should work better in the interim

further test and verification on similar limits for pgsql requires