### PR TITLE
null value compatibility fix for php 8.1

### DIFF
--- a/lib/VacationConfig.class.php
+++ b/lib/VacationConfig.class.php
@@ -67,9 +67,9 @@ class VacationConfig
         // Get normalized hostname
 	public function setCurrentHost($host)
 	{
-		if (! $this->currentHost = parse_url($host,PHP_URL_HOST))
+		if (! $this->currentHost = parse_url($host ?? '',PHP_URL_HOST))
 		{
-			$this->currentHost = parse_url($host,PHP_URL_PATH);
+			$this->currentHost = parse_url($host ?? '',PHP_URL_PATH);
 		}
 	}
 


### PR DESCRIPTION
address deprecated notice:
"parse_url(): Passing null to parameter #1 ($url) of type string is deprecated "