### PR TITLE
compatibility fix for roundcube 1.7.x and above

### DIFF
--- a/lib/VacationConfig.class.php
+++ b/lib/VacationConfig.class.php
@@ -45,6 +45,11 @@ class VacationConfig
 	private function parseIni()
 	{
 		$configini = "plugins/vacation/config.ini";		
+
+    if (version_compare(RCMAIL_VERSION, '1.7.0', '>=')) {
+      $configini = INSTALL_PATH . "plugins/vacation/config.ini";
+    }
+
 		if (! is_readable($configini))
 		{
 			$this->hasError = $configini." is not readable";

--- a/lib/vacationdriver.class.php
+++ b/lib/vacationdriver.class.php
@@ -58,7 +58,10 @@ public function loadDefaults() {
 
 
     $file = "plugins/vacation/" . $this->cfg['body'];
-    
+
+    if (version_compare(RCMAIL_VERSION, '1.7.0', '>=')) {
+      $file = INSTALL_PATH . "plugins/vacation/" . $this->cfg['body'];
+    }
 
     if (is_readable($file)) {
         $defaults = array('subject'=>$this->cfg['subject']);

--- a/lib/vacationfactory.class.php
+++ b/lib/vacationfactory.class.php
@@ -23,8 +23,12 @@ class VacationDriverFactory {
 	 * @return object specific driver */
     public static function Create( $driver ) {
         $driver = strtolower($driver);
-		$driverclass = sprintf("plugins/vacation/lib/%s.class.php",$driver);
-		
+	$driverclass = sprintf("plugins/vacation/lib/%s.class.php",$driver);
+
+    if (version_compare(RCMAIL_VERSION, '1.7.0', '>=')) {
+      $driverclass = sprintf(INSTALL_PATH . "plugins/vacation/lib/%s.class.php",$driver);
+    }
+
         if (! is_readable($driverclass)) {
              rcube::raise_error(array('code' => 601,'type' => 'php','file' => __FILE__,
                 'message' => sprintf("Vacation plugin: Driver '%s' cannot be loaded using %s",$driver,$driverclass)

--- a/lib/virtual.class.php
+++ b/lib/virtual.class.php
@@ -273,17 +273,18 @@ class Virtual extends VacationDriver {
 
         $rows = array();
 
-        while (list($row) = $this->db->fetch_array($res)) {
+        while ($result = $this->db->fetch_array($res)) {
+          $row = $result[0] ?? null;
 
-            // Postfix accepts multiple aliases on 1 row as well as an alias per row
+          if ($row !== null) {
+          // Postfix accepts multiple aliases on 1 row as well as an alias per row
             if (strpos($row, ",") !== false) {
-                $rows = explode(",", $row);
+              $rows = array_merge($rows, explode(",", $row));
             } else {
-                $rows[] = $row;
+              $rows[] = $row;
             }
+          }
         }
-
-
 
         foreach ($rows as $row) {
             // Source = destination means keep a local copy


### PR DESCRIPTION
roundcube 1.7.x use a pseudo public_html directory to serve.
this breaks how config.ini is read and located.
